### PR TITLE
Optimize footer for small laptops

### DIFF
--- a/components/footer/footer.css
+++ b/components/footer/footer.css
@@ -12,7 +12,7 @@
     min-height: 420px;
 }
 
-@media (min-width: 1300px) {
+@media (min-width: 1025px) {
     .dsa-footer {
         min-height: 240px;
     }
@@ -32,9 +32,9 @@
     width: 100%;
 }
 
-@media (min-width: 1300px) {
+@media (min-width: 1025px) {
     .dsa-footer-inner {
-        padding: 2rem 2rem 4rem 2rem;
+        padding: 2rem 1rem 4rem 1rem;
     }
 }
 
@@ -52,7 +52,7 @@
     color: #fff;
 }
 
-@media (min-width: 1300px) {
+@media (min-width: 1025px) {
     .dsa-footer-slogan {
         margin: 0 0 4rem 0;
     }
@@ -89,7 +89,7 @@
     width: 100%;
 }
 
-@media (min-width: 1300px) {
+@media (min-width: 1025px) {
     .dsa-footer-ul {
         display: flex;
     }
@@ -106,7 +106,13 @@
     color: #fff;
 }
 
-@media (min-width: 1300px) {
+@media (min-width: 1025px) {
+    .dsa-footer-link {
+        margin: 0 1.125rem 0 0;
+    }
+}
+
+@media (min-width: 1156px) {
     .dsa-footer-link {
         margin: 0 2rem 0 0;
     }


### PR DESCRIPTION
In this pull request:
- Wrap footer into mobile view on 1025px, not 1300px for better design on small laptops.
- Tweak margin between links in footer, to prevent line wrap.
- Align footer with header, since footer was a bit smaler than header. This will give us 2rem better space.


**Mobile up to 1024px:**

![Skjermbilde 2022-06-02 kl  13 09 11](https://user-images.githubusercontent.com/29566394/171616823-cb5c8522-c5e5-4f16-b863-e763ab53fc54.png)

**Small desktops, from 1025px to 1156px, 1.125rem between links:**

![Skjermbilde 2022-06-02 kl  13 09 29](https://user-images.githubusercontent.com/29566394/171616964-a78f6d78-08b9-413b-8eb1-ebc6e5412b19.png)

**From 1156px and up, 2rem between links:**

![Skjermbilde 2022-06-02 kl  13 09 47](https://user-images.githubusercontent.com/29566394/171617023-9f8c32e5-3348-4835-9b88-134f86bf6f14.png)

 