### PR TITLE
Bruker neutral Button istedet for egen button

### DIFF
--- a/src/packages/arbeidsplassen-css/button.css
+++ b/src/packages/arbeidsplassen-css/button.css
@@ -1,3 +1,0 @@
-.arb-button {
-  cursor: pointer;
-}

--- a/src/packages/arbeidsplassen-css/feedback.css
+++ b/src/packages/arbeidsplassen-css/feedback.css
@@ -1,28 +1,11 @@
 .arb-feedback-button {
-  padding: 0.5rem;
-  min-width: 6.5rem;
-  border-radius: var(--a-border-radius-medium);
-  background: none;
-  border: 0;
+  min-width: 5rem;
+}
+
+.arb-feedback-button-inner {
   display: flex;
-  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  gap: 0.5rem;
-  font-size: 1rem;
-  line-height: 1.5rem;
-  font-weight: 600;
-}
-
-.arb-feedback-button:hover {
-  background-color: var(--a-surface-neutral-subtle-hover);
-}
-
-.arb-feedback-button:focus {
-  outline: none;
-  box-shadow: var(--a-shadow-focus);
-}
-
-.arb-feedback-button:active {
-  background-color: var(--a-surface-neutral-active);
-  color: var(--a-text-on-neutral);
+  flex-direction: column;
+  gap: var(--a-spacing-2);
 }

--- a/src/packages/arbeidsplassen-css/index.css
+++ b/src/packages/arbeidsplassen-css/index.css
@@ -7,4 +7,3 @@
 @import "./container.css";
 @import "./spacing.css";
 @import "./typography.css";
-@import "./button.css";

--- a/src/packages/arbeidsplassen-css/package.json
+++ b/src/packages/arbeidsplassen-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/arbeidsplassen-css",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "main": "index.css",
   "private": false,
   "scripts": {

--- a/src/packages/arbeidsplassen-react/Feedback/FeedbackButton.js
+++ b/src/packages/arbeidsplassen-react/Feedback/FeedbackButton.js
@@ -1,27 +1,26 @@
 import React from "react";
+import { Button } from "@navikt/ds-react";
 
 function FeedbackButton({
   children,
   icon,
+  variant = "tertiary-neutral",
   className,
-  onClick,
-  htmlType = "button",
-  ariaDescribedBy,
+  ...rest
 }) {
   return (
-    <button
-      aria-describedby={ariaDescribedBy}
-      type={htmlType}
+    <Button
+      variant={variant}
       className={
-        className + "arb-button"
-          ? `arb-button arb-feedback-button ${className}`
-          : "arb-button arb-feedback-button"
+        className ? `arb-feedback-button ${className}` : "arb-feedback-button"
       }
-      onClick={onClick}
+      {...rest}
     >
-      {icon}
-      {children}
-    </button>
+      <span className="arb-feedback-button-inner">
+        {icon}
+        {children}
+      </span>
+    </Button>
   );
 }
 

--- a/src/packages/arbeidsplassen-react/package.json
+++ b/src/packages/arbeidsplassen-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/arbeidsplassen-react",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "main": "dist/index.js",
   "private": false,
   "scripts": {

--- a/src/packages/arbeidsplassen-theme/package.json
+++ b/src/packages/arbeidsplassen-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/arbeidsplassen-theme",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "main": "index.css",
   "private": false,
   "scripts": {

--- a/src/pages/FeedbackButton.js
+++ b/src/pages/FeedbackButton.js
@@ -41,7 +41,7 @@ const FeedbackButtonExample = () => {
           </Heading>
           <HStack gap="2" justify="center">
             <FeedbackButton
-              ariaDescribedBy="poll-title"
+              aria-describedby="poll-title"
               icon={
                 <FaceSmileIcon
                   aria-hidden="true"
@@ -53,7 +53,7 @@ const FeedbackButtonExample = () => {
               Ja
             </FeedbackButton>
             <FeedbackButton
-              ariaDescribedBy="poll-title"
+              aria-describedby="poll-title"
               icon={
                 <FaceFrownIcon
                   aria-hidden="true"
@@ -65,7 +65,7 @@ const FeedbackButtonExample = () => {
               Nei
             </FeedbackButton>
             <FeedbackButton
-              ariaDescribedBy="poll-title"
+              aria-describedby="poll-title"
               icon={
                 <FaceIcon aria-hidden="true" height="1.5rem" width="1.5rem" />
               }


### PR DESCRIPTION
`FeedbackButton` var laget som en helt egen komponent, men vi fant at den manglet `cursor: pointer`, og dessuten en del andre ting. Bytter derfor om slik at den bruker en Button fra Aksel i stedet, siden denne både har bedre støtte for diverse html props og at den allerede er cross browser / device testet.

BREAKING: `ariaDescibedBy` må renames til `aria-describedby` i repoene som bruker knappen.