### PR TITLE
Add new cookie banner component

### DIFF
--- a/src/examples/Layout.js
+++ b/src/examples/Layout.js
@@ -2,9 +2,11 @@ import Link from "next/link";
 import { BodyLong, Heading, HGrid, Link as AkselLink } from "@navikt/ds-react";
 import SkipLink from "@navikt/arbeidsplassen-react/SkipLink/SkipLink";
 import { Footer, Header } from "@navikt/arbeidsplassen-react";
+import { CookieBanner } from "@navikt/arbeidsplassen-react/CookieBanner";
 
 const arbeidsplassenComponents = [
   "ComboboxExternalItems",
+  "CookieBanner",
   "FeedbackButton",
   "Header",
   "Illustrations",
@@ -52,7 +54,12 @@ const akselComponents = [
   "Typography",
 ].sort();
 
-export default function Layout({ children, title, headerArgs }) {
+export default function Layout({
+  children,
+  title,
+  headerArgs,
+  cookieBannerArgs,
+}) {
   headerArgs = {
     onLogin: console.log,
     onLogout: console.log,
@@ -61,6 +68,12 @@ export default function Layout({ children, title, headerArgs }) {
   return (
     <>
       <div className="arb-push-footer-down">
+        {cookieBannerArgs && (
+          <CookieBanner
+            onNecessaryOnlyClick={cookieBannerArgs.onNecessaryOnlyClick}
+            onAcceptAllClick={cookieBannerArgs.onAcceptAllClick}
+          />
+        )}
         <SkipLink />
         <Header
           variant={headerArgs.variant}

--- a/src/packages/arbeidsplassen-react/CookieBanner/CookieBanner.js
+++ b/src/packages/arbeidsplassen-react/CookieBanner/CookieBanner.js
@@ -1,0 +1,71 @@
+import React from "react";
+import {
+  BodyLong,
+  Box,
+  Button,
+  Heading,
+  Label,
+  Link,
+  List,
+  Stack,
+} from "@navikt/ds-react";
+import PropTypes from "prop-types";
+import { ListItem } from "@navikt/ds-react/List";
+
+function CookieBanner({ onNecessaryOnlyClick, onAcceptAllClick }) {
+  return (
+    <Box
+      as="section"
+      aria-labelledby="arb-cookie-banner-title"
+      padding={{ xs: "6 0", md: "8 0" }}
+      background="surface-alt-2-subtle"
+    >
+      <div className="container-large">
+        <Heading level="1" size="large" spacing id="arb-cookie-banner-title">
+          Informasjonskapsler på arbeidsplassen.no
+        </Heading>
+        <BodyLong>
+          Uansett valg deler vi aldri dine data med andre.{" "}
+          <Link href="/informasjonskapsler" variant="neutral" inlineText>
+            Mer om informasjonskapsler på arbeidsplassen.no
+          </Link>
+        </BodyLong>
+
+        <List aria-label="Beskrivelse av valgene du har:" className="mb-8">
+          <ListItem>
+            <Label as="span">Bare nødvendige:</Label> Sikrer at tjenesten
+            fungerer og er trygg. Kan ikke velges bort.
+          </ListItem>
+          <ListItem>
+            <Label as="span">Godta alle:</Label> Hjelper oss gjøre tjenestene
+            bedre for deg basert på anonymisert bruk.
+          </ListItem>
+        </List>
+
+        <Stack gap="2" direction={{ xs: "column", sm: "row" }}>
+          <Button
+            type="button"
+            variant="secondary-neutral"
+            onClick={onNecessaryOnlyClick}
+          >
+            Bare nødvendige
+          </Button>
+          <Button
+            type="button"
+            variant="secondary-neutral"
+            onClick={onAcceptAllClick}
+          >
+            Godta alle
+          </Button>
+        </Stack>
+      </div>
+    </Box>
+  );
+}
+
+CookieBanner.propTypes = {
+  onNecessaryOnlyClick: PropTypes.func.isRequired,
+  onAcceptAllClick: PropTypes.func.isRequired,
+};
+
+export default CookieBanner;

--- a/src/packages/arbeidsplassen-react/CookieBanner/index.js
+++ b/src/packages/arbeidsplassen-react/CookieBanner/index.js
@@ -1,0 +1,1 @@
+export { default as CookieBanner } from "./CookieBanner.js";

--- a/src/pages/CookieBanner.js
+++ b/src/pages/CookieBanner.js
@@ -1,0 +1,34 @@
+import { Switch } from "@navikt/ds-react";
+import Layout from "../examples/Layout";
+import { useState } from "react";
+
+const CookieBannerExample = () => {
+  const [showCookieBanner, setShowCookieBanner] = useState(true);
+
+  return (
+    <Layout
+      title="CookieBanner"
+      cookieBannerArgs={
+        showCookieBanner
+          ? {
+              onNecessaryOnlyClick: () => {
+                setShowCookieBanner(false);
+              },
+              onAcceptAllClick: () => {
+                setShowCookieBanner(false);
+              },
+            }
+          : false
+      }
+    >
+      <Switch
+        checked={showCookieBanner}
+        onChange={(e) => setShowCookieBanner(e.target.checked)}
+      >
+        Vis cookie banner
+      </Switch>
+    </Layout>
+  );
+};
+
+export default CookieBannerExample;


### PR DESCRIPTION
Lager ny felleskomponent for cookie banner

- Banner er inline, slik at den ikke vil dekke over annet innhold
- `<CoockieBanner />` bør plasseres før `<SkipLink />` helt øverst på siden
- Hver app må selv vise/skjule cookie banner
- CoockieBanner har to callbacks for `onNecessaryOnlyClick` og `onAcceptAllClick`

<img width="1629" alt="Skjermbilde 2025-02-14 kl  14 25 37" src="https://github.com/user-attachments/assets/04eb2ce0-f421-40f7-9b87-de00262af17b" />
