### PR TITLE
Fix header types

### DIFF
--- a/src/packages/arbeidsplassen-react/Header/Header.js
+++ b/src/packages/arbeidsplassen-react/Header/Header.js
@@ -17,7 +17,7 @@ function joinClassNames(...strings) {
  * @typedef { "company" | "person" | "all"  } Variant
  */
 /**
- * @typedef { "ledige-stillinger" |"cv" | "stillingsannonser" } Active
+ * @typedef { "ledige-stillinger" |"cv" | "stillingsannonser" | "sommerjobb" } Active
  */
 
 /**
@@ -116,5 +116,6 @@ Header.propTypes = {
     "ledige-stillinger",
     "cv",
     "stillingsannonser",
+      "sommerjobb"
   ]),
 };

--- a/src/packages/arbeidsplassen-react/package.json
+++ b/src/packages/arbeidsplassen-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/arbeidsplassen-react",
-  "version": "8.7.5",
+  "version": "8.7.6",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "private": false,


### PR DESCRIPTION
- version bump

This pull request adds support for a new "sommerjobb" (summer job) section to the `Header` component in the `arbeidsplassen-react` package. This allows the header to recognize and properly handle the "sommerjobb" value as an active tab or section.

Support for "sommerjobb" in the Header component:

* Extended the `Active` type definition in `Header.js` to include "sommerjobb", enabling it as a valid active section.
* Updated the `Header.propTypes` validation to allow "sommerjobb" as a valid value for the `active` prop.

Version bump:

* Incremented the package version from `8.7.5` to `8.7.6` in `package.json` to reflect the new feature addition.