### PR TITLE
CookieBanner bytt rekkefølge på knapper

### DIFF
--- a/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerA.tsx
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerA.tsx
@@ -159,19 +159,20 @@ function CookieBannerA({
                     <Button
                         type="button"
                         variant="secondary-neutral"
-                        onClick={handleAcceptAllClick}
-                        data-testid="accept-all"
-                    >
-                        Godta alle informasjonskapsler
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="secondary-neutral"
                         onClick={handleNecessaryOnlyClick}
                         data-testid="necessary-only"
                     >
                         Kun nødvendige
                     </Button>
+                    <Button
+                        type="button"
+                        variant="secondary-neutral"
+                        onClick={handleAcceptAllClick}
+                        data-testid="accept-all"
+                    >
+                        Godta alle informasjonskapsler
+                    </Button>
+
                 </Stack>
             </div>
         </Box>

--- a/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerB.tsx
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerB.tsx
@@ -154,11 +154,11 @@ export default function CookieBannerB({
                 </BodyLong>
 
                 <Stack gap="2" direction={{ xs: "column", sm: "row" }}>
-                    <Button type="button" variant="secondary-neutral" onClick={handleAcceptAllClick}>
-                        Godta alle informasjonskapsler
-                    </Button>
                     <Button type="button" variant="secondary-neutral" onClick={handleNecessaryOnlyClick}>
                         Kun nødvendige
+                    </Button>
+                    <Button type="button" variant="secondary-neutral" onClick={handleAcceptAllClick}>
+                        Godta alle informasjonskapsler
                     </Button>
                 </Stack>
             </div>

--- a/src/packages/arbeidsplassen-react/package.json
+++ b/src/packages/arbeidsplassen-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/arbeidsplassen-react",
-  "version": "8.7.6",
+  "version": "8.7.7",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "private": false,


### PR DESCRIPTION
This pull request updates the button order and labeling in both `CookieBannerA` and `CookieBannerB` components to improve clarity and user experience. Additionally, it increments the package version to reflect these changes.

**UI improvements to cookie banners:**

* Swapped the order of the "Godta alle informasjonskapsler" and "Kun nødvendige" buttons in `CookieBannerA`, and updated their respective click handlers and test IDs to match the button text. (`src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerA.tsx`)
* Reordered the buttons in `CookieBannerB` so that "Kun nødvendige" appears before "Godta alle informasjonskapsler", aligning the UI with the updated design. (`src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerB.tsx`)

**Version update:**

* Bumped the package version from `8.7.6` to `8.7.7` in `package.json` to reflect the UI changes. (`src/packages/arbeidsplassen-react/package.json`)