### PR TITLE
Fjerne surveysConsent fra cookiebanner cookie

### DIFF
--- a/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerA.tsx
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerA.tsx
@@ -54,7 +54,7 @@ const buildConsentData = (acceptedAll: boolean): ConsentData => {
     const nowIso = new Date().toISOString();
 
     return {
-        consent: { analytics: acceptedAll, surveys: acceptedAll },
+        consent: { analytics: acceptedAll },
         userActionTaken: true,
         meta: { createdAt, updatedAt: nowIso, version: CONSENT_VERSION },
     };

--- a/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerB.tsx
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerB.tsx
@@ -54,7 +54,7 @@ const buildConsentData = (acceptedAll: boolean): ConsentData => {
     const nowIso = new Date().toISOString();
 
     return {
-        consent: { analytics: acceptedAll, surveys: acceptedAll },
+        consent: { analytics: acceptedAll },
         userActionTaken: true,
         meta: { createdAt, updatedAt: nowIso, version: CONSENT_VERSION },
     };

--- a/src/packages/arbeidsplassen-react/CookieBannerAB/cookieBannerUtils.ts
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/cookieBannerUtils.ts
@@ -2,7 +2,6 @@
 export type ConsentData = {
     consent: {
         analytics: boolean;
-        surveys: boolean;
     };
     userActionTaken: boolean;
     meta: {
@@ -14,7 +13,6 @@ export type ConsentData = {
 
 export type ConsentValues = {
     analyticsConsent: boolean;
-    surveysConsent: boolean;
 };
 
 /** --- Konstanter --- */
@@ -43,7 +41,6 @@ function validateConsentData(input: unknown): input is ConsentData {
 
     if (!isObject(consent)) return false;
     if (!isBoolean(consent.analytics)) return false;
-    if (!isBoolean(consent.surveys)) return false;
 
     if (!isBoolean(userActionTaken)) return false;
 
@@ -68,7 +65,7 @@ function assertConsentData(input: unknown): asserts input is ConsentData {
 
 /** Default-objekt (brukes ved fallback) */
 const makeDefaultConsentData = (nowISO: string = new Date().toISOString()): ConsentData => ({
-    consent: { analytics: false, surveys: false },
+    consent: { analytics: false },
     userActionTaken: false,
     meta: { createdAt: nowISO, updatedAt: nowISO, version: CURRENT_VERSION },
 });
@@ -157,7 +154,6 @@ export function getConsentValues(cookies?: string | null): ConsentValues {
     const existing = getCookie(cookies);
     return {
         analyticsConsent: existing?.consent.analytics ?? false,
-        surveysConsent: existing?.consent.surveys ?? false,
     };
 }
 
@@ -171,7 +167,6 @@ export function updateConsent(
     const next: ConsentData = {
         consent: {
             analytics: partial.consent?.analytics ?? current.consent.analytics,
-            surveys: partial.consent?.surveys ?? current.consent.surveys,
         },
         userActionTaken: partial.userActionTaken ?? current.userActionTaken,
         meta: {

--- a/src/packages/arbeidsplassen-react/package.json
+++ b/src/packages/arbeidsplassen-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/arbeidsplassen-react",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "private": false,


### PR DESCRIPTION
This pull request removes support for the `surveys` consent option from the cookie banner components and related utilities. All code handling survey consent has been deleted, leaving only the `analytics` consent option. The version number has also been incremented to reflect this change.

Consent data model and logic simplification:

* Removed the `surveys` field from the `ConsentData` and `ConsentValues` types in `cookieBannerUtils.ts`, so only `analytics` consent is tracked. [[1]](diffhunk://#diff-f235a513a0a5d56a3bb0c7ea0193833338b5cc9c8e35e293204db00717f1fd12L5) [[2]](diffhunk://#diff-f235a513a0a5d56a3bb0c7ea0193833338b5cc9c8e35e293204db00717f1fd12L17)
* Updated all functions in `cookieBannerUtils.ts` (`validateConsentData`, `assertConsentData`, `getConsentValues`, `updateConsent`, and `makeDefaultConsentData`) to remove handling of the `surveys` field. [[1]](diffhunk://#diff-f235a513a0a5d56a3bb0c7ea0193833338b5cc9c8e35e293204db00717f1fd12L46) [[2]](diffhunk://#diff-f235a513a0a5d56a3bb0c7ea0193833338b5cc9c8e35e293204db00717f1fd12L71-R68) [[3]](diffhunk://#diff-f235a513a0a5d56a3bb0c7ea0193833338b5cc9c8e35e293204db00717f1fd12L160) [[4]](diffhunk://#diff-f235a513a0a5d56a3bb0c7ea0193833338b5cc9c8e35e293204db00717f1fd12L174)
* Modified `buildConsentData` in both `CookieBannerA.tsx` and `CookieBannerB.tsx` to only include `analytics` consent. [[1]](diffhunk://#diff-66550d0cc98903450bab4661582f64d9e82f41faa2c42ec6e4b12bac18ffe1fdL57-R57) [[2]](diffhunk://#diff-857ddcef02b3565ae96b6e40214b081b63b6f49f541a3ec596b6e82c99590246L57-R57)

Version bump:

* Updated the package version in `package.json` from `8.8.1` to `8.8.2` to reflect the breaking change.