### PR TITLE
feat(consent): migrer legacy-cookie til V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
-## Ta i bruk designsystemet i ditt prosjekt
+# Ta i bruk designsystemet i ditt prosjekt
 
 Vi bruker design-komponentene til [Aksel](https://aksel.nav.no/) med vår egen "theme" som endrer farger og noen
 utvalgte css-variabler. I tillegg har vi noen egne React-komponenter, slik som `Header` og `Footer`.
 
-**Installasjon**
+## Installasjon
 
 ```bash
 npm install @navikt/ds-react @navikt/ds-css @navikt/arbeidsplassen-react @navikt/arbeidsplassen-css
 ```
 
-**Bruk**
+### Installer pakken sammen med Zod:
+```bash
+npm install zod@^4.1.11
+```
+
+⚠️ Merk:
+Denne pakken bruker Zod til validering, men inkluderer det ikke selv.
+Applikasjonen din må derfor ha zod installert som avhengighet.
+Vi støtter og tester kun mot Zod v4 (^4.1.11).
+
+## Bruk
 
 Legg til `data-theme="arbeidsplassen"` på for eksempel `body` i koden for å aktivere arbeidsplassen
 sitt "theme".
@@ -28,7 +38,7 @@ import { Header, Footer } from "@navikt/arbeidsplassen-react";
 import { Button, TextField } from "@navikt/ds-react";
 ```
 
-### Hvordan få tilgang til @navikt/arbeidsplassen-react og @navikt/arbeidsplassen-css
+## Hvordan få tilgang til @navikt/arbeidsplassen-react og @navikt/arbeidsplassen-css
 
 Opprett fila `.npmrc` i hjemkatalogen din. F.eks. `~/.npmrc` Mer info: https://docs.npmjs.com/cli/v9/configuring-npm/npmrc
 
@@ -58,12 +68,12 @@ Eksempel-appen kjører på [http://localhost:3001](http://localhost:3001)
 
 ## Publisere nye versjoner
 
-**arbeidsplassen-react**
+### arbeidsplassen-react
 
 - Endre `version` i `src/packages/arbeidsplassen-react/package.json` til ny versjon du ønsker å publisere.
 - Kjør `Publish REACT package` workflow under fanen `Actions` på repositoryet på Github (https://github.com/navikt/arbeidsplassen-design/actions)
 
-**arbeidsplassen-css**
+### arbeidsplassen-css
 
 - Endre `version` i `src/packages/arbeidsplassen-css/package.json` til ny versjon du ønsker å publisere.
 - Kjør `Publish CSS package` workflow under fanen `Actions` på repositoryet på Github (https://github.com/navikt/arbeidsplassen-design/actions)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "prop-types": "^15.8.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "typescript": "5.6.3"
+        "typescript": "5.6.3",
+        "zod": "^4.1.11"
       },
       "devDependencies": {
         "@babel/preset-typescript": "^7.27.1",
@@ -3278,6 +3279,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "src/packages/arbeidsplassen-css": {
       "name": "@navikt/arbeidsplassen-css",
       "version": "8.5.0",
@@ -3286,7 +3296,7 @@
     },
     "src/packages/arbeidsplassen-react": {
       "name": "@navikt/arbeidsplassen-react",
-      "version": "8.8.1",
+      "version": "8.8.2",
       "license": "ISC",
       "dependencies": {
         "@babel/polyfill": "^7.12.1"
@@ -5427,6 +5437,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "zod": "^4.1.11"
   },
   "publishConfig": {
     "access": "public"

--- a/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerA.tsx
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerA.tsx
@@ -1,182 +1,181 @@
-import  React, { useEffect, useMemo } from "react";
-
-import {ConsentData, getCreatedAtValue, setCookie} from "./cookieBannerUtils";
-import {BodyLong, BodyShort, Box, Button, Heading, Link, Stack} from "@navikt/ds-react";
+import React, { useEffect, useMemo } from "react";
+import { updateConsent } from "./cookieBannerUtils";
+import {
+  BodyLong,
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  Link,
+  Stack,
+} from "@navikt/ds-react";
 
 export type CookieBannerVariant = "A" | "B";
 export type CookieBannerAcceptedPayload = Readonly<{
-    variant: CookieBannerVariant;
-    url: string;
+  variant: CookieBannerVariant;
+  url: string;
 }>;
 
 type HeadingLevel = "1" | "2" | "3" | "4" | "5" | "6";
 
 export type CookieBannerProps = {
-    headingLevel?: HeadingLevel;
+  headingLevel?: HeadingLevel;
 
-    /** Kalles hvis lagring av cookie feiler */
-    onError?: (error: unknown) => void;
+  /** Kalles hvis lagring av cookie feiler */
+  onError?: (error: unknown) => void;
 
-    /** Eksterne hooks – disse kalles ETTER at komponenten ev. har satt cookie */
-    onNecessaryOnly?: () => void;
-    onAcceptAll?: () => void;
+  /** Eksterne hooks – disse kalles ETTER at komponenten ev. har satt cookie */
+  onNecessaryOnly?: () => void;
+  onAcceptAll?: () => void;
 
-    /** Lifecycle */
-    onOpen?: () => void;
-    onClose?: () => void;
+  /** Lifecycle */
+  onOpen?: () => void;
+  onClose?: () => void;
 
-    /**
-     * Bevar disse localStorage-nøklene når banneret vises (clear + reinsert).
-     * Default: ["isDebug"].
-     */
-    preserveLocalStorageKeys?: readonly string[];
+  /**
+   * Bevar disse localStorage-nøklene når banneret vises (clear + reinsert).
+   * Default: ["isDebug"].
+   */
+  preserveLocalStorageKeys?: readonly string[];
 
-    /**
-     * Default: false.
-     * Hvis true, så vil komponenten IKKE sette consent-cookie automatisk.
-     * Du kan da selv håndtere lagring i onAcceptAll/onNecessaryOnly.
-     */
-    disableAutoCookie?: boolean;
+  /**
+   * Default: false.
+   * Hvis true, så vil komponenten IKKE sette consent-cookie automatisk.
+   * Du kan da selv håndtere lagring i onAcceptAll/onNecessaryOnly.
+   */
+  disableAutoCookie?: boolean;
 
-    /** Just in case du vil endre lenke/tekst uten å wrappe komponenten */
-    cookieInfoHref?: string;
-    titleId?: string;
-    sectionId?: string;
-    variant?: CookieBannerVariant;
-    getUrl?: () => string;
-    onAcceptedAllTrack?: (payload: CookieBannerAcceptedPayload) => void;
+  /** Just in case du vil endre lenke/tekst uten å wrappe komponenten */
+  cookieInfoHref?: string;
+  titleId?: string;
+  sectionId?: string;
+  variant?: CookieBannerVariant;
+  getUrl?: () => string;
+  onAcceptedAllTrack?: (payload: CookieBannerAcceptedPayload) => void;
 };
 
-const CONSENT_VERSION = 1 as const;
-
-const buildConsentData = (acceptedAll: boolean): ConsentData => {
-    const createdAt = getCreatedAtValue();
-    const nowIso = new Date().toISOString();
-
-    return {
-        consent: { analytics: acceptedAll },
-        userActionTaken: true,
-        meta: { createdAt, updatedAt: nowIso, version: CONSENT_VERSION },
-    };
-};
 const defaultGetUrl = (): string => {
-    if (typeof window === "undefined") return "/";
-    return window.location.pathname;
+  if (typeof window === "undefined") return "/";
+  return window.location.pathname;
 };
 function CookieBannerA({
-    headingLevel = "1",
-    onError,
-    onNecessaryOnly,
-    onAcceptAll,
-    onOpen,
-    onClose,
-    preserveLocalStorageKeys = ["isDebug"],
-    disableAutoCookie = false,
-    cookieInfoHref = "/informasjonskapsler",
-    titleId = "arb-cookie-banner-title",
-    sectionId = "arb-cookie-banner-section",
-    variant = "A",
-    getUrl = defaultGetUrl,
-    onAcceptedAllTrack,
+  headingLevel = "1",
+  onError,
+  onNecessaryOnly,
+  onAcceptAll,
+  onOpen,
+  onClose,
+  preserveLocalStorageKeys = ["isDebug"],
+  disableAutoCookie = false,
+  cookieInfoHref = "/informasjonskapsler",
+  titleId = "arb-cookie-banner-title",
+  sectionId = "arb-cookie-banner-section",
+  variant = "A",
+  getUrl = defaultGetUrl,
+  onAcceptedAllTrack,
 }: CookieBannerProps) {
-    // memoize lista slik at effect ikke rerunner pga referanseendring
-    const preservedKeys = useMemo<readonly string[]>(() => preserveLocalStorageKeys, [preserveLocalStorageKeys]);
+  // memoize lista slik at effect ikke rerunner pga referanseendring
+  const preservedKeys = useMemo<readonly string[]>(
+    () => preserveLocalStorageKeys,
+    [preserveLocalStorageKeys]
+  );
 
-    useEffect(() => {
-        try {
-            const preserved: Record<string, string> = {};
-            preservedKeys.forEach((key) => {
-                const val = localStorage.getItem(key);
-                if (val !== null) preserved[key] = val;
-            });
+  useEffect(() => {
+    try {
+      const preserved: Record<string, string> = {};
+      preservedKeys.forEach((key) => {
+        const val = localStorage.getItem(key);
+        if (val !== null) preserved[key] = val;
+      });
 
-            localStorage.clear();
+      localStorage.clear();
 
-            Object.entries(preserved).forEach(([k, v]) => {
-                localStorage.setItem(k, v);
-            });
-        } catch {
-            // Bevisst stilletiende – localStorage kan være disabled
-        }
-    }, [preservedKeys]);
+      Object.entries(preserved).forEach(([k, v]) => {
+        localStorage.setItem(k, v);
+      });
+    } catch {
+      // Bevisst stilletiende – localStorage kan være disabled
+    }
+  }, [preservedKeys]);
 
-    useEffect(() => {
-        onOpen?.();
-    }, [onOpen]);
+  useEffect(() => {
+    onOpen?.();
+  }, [onOpen]);
 
-    const persistConsentSafely = (acceptedAll: boolean): void => {
-        if (disableAutoCookie) return;
-        try {
-            const data = buildConsentData(acceptedAll);
-            setCookie(data);
-        } catch (err) {
-            onError?.(err);
-        }
-    };
+  const persistConsentSafely = (acceptedAll: boolean): void => {
+    if (disableAutoCookie) return;
+    try {
+      updateConsent({
+        consent: { analytics: acceptedAll },
+        userActionTaken: true,
+      });
+    } catch (err) {
+      onError?.(err);
+    }
+  };
 
-    const handleNecessaryOnlyClick = (): void => {
-        persistConsentSafely(false);
-        onNecessaryOnly?.();
-        onClose?.();
-    };
+  const handleNecessaryOnlyClick = (): void => {
+    persistConsentSafely(false);
+    onNecessaryOnly?.();
+    onClose?.();
+  };
 
-    const handleAcceptAllClick = (): void => {
-        persistConsentSafely(true);
-        onAcceptAll?.();
-        onClose?.();
-        onAcceptedAllTrack?.({
-            variant,
-            url: getUrl(),
-        });
-    };
+  const handleAcceptAllClick = (): void => {
+    persistConsentSafely(true);
+    onAcceptAll?.();
+    onClose?.();
+    onAcceptedAllTrack?.({
+      variant,
+      url: getUrl(),
+    });
+  };
 
-    return (
-        <Box
-            as="section"
-            aria-labelledby={titleId}
-            id={sectionId}
-            padding={{ xs: "6", md: "8" }}
-            background="surface-alt-2-subtle"
-        >
-            <div className="container-large">
-                <Heading level={headingLevel} size="large" spacing id={titleId}>
-                    Vi bruker cookies
-                </Heading>
+  return (
+    <Box
+      as="section"
+      aria-labelledby={titleId}
+      id={sectionId}
+      padding={{ xs: "6", md: "8" }}
+      background="surface-alt-2-subtle"
+    >
+      <div className="container-large">
+        <Heading level={headingLevel} size="large" spacing id={titleId}>
+          Vi bruker cookies
+        </Heading>
 
-                <BodyShort spacing>
-                    Vi bruker nødvendige cookies for at siden skal fungere. Godtar du alle, kan vi bruke anonymisert
-                    statistikk til å forbedre jobbsøket.
-                    <strong> Uansett valg deler vi aldri dine data med andre.</strong>
-                </BodyShort>
+        <BodyShort spacing>
+          Vi bruker nødvendige cookies for at siden skal fungere. Godtar du
+          alle, kan vi bruke anonymisert statistikk til å forbedre jobbsøket.
+          <strong> Uansett valg deler vi aldri dine data med andre.</strong>
+        </BodyShort>
 
-                <BodyLong spacing>
-                    <Link href={cookieInfoHref} variant="neutral" inlineText>
-                        Mer om informasjonskapsler på arbeidsplassen.no
-                    </Link>
-                </BodyLong>
+        <BodyLong spacing>
+          <Link href={cookieInfoHref} variant="neutral" inlineText>
+            Mer om informasjonskapsler på arbeidsplassen.no
+          </Link>
+        </BodyLong>
 
-                <Stack gap="2" direction={{ xs: "column", sm: "row" }}>
-                    <Button
-                        type="button"
-                        variant="secondary-neutral"
-                        onClick={handleNecessaryOnlyClick}
-                        data-testid="necessary-only"
-                    >
-                        Kun nødvendige
-                    </Button>
-                    <Button
-                        type="button"
-                        variant="secondary-neutral"
-                        onClick={handleAcceptAllClick}
-                        data-testid="accept-all"
-                    >
-                        Godta alle informasjonskapsler
-                    </Button>
-
-                </Stack>
-            </div>
-        </Box>
-    );
+        <Stack gap="2" direction={{ xs: "column", sm: "row" }}>
+          <Button
+            type="button"
+            variant="secondary-neutral"
+            onClick={handleNecessaryOnlyClick}
+            data-testid="necessary-only"
+          >
+            Kun nødvendige
+          </Button>
+          <Button
+            type="button"
+            variant="secondary-neutral"
+            onClick={handleAcceptAllClick}
+            data-testid="accept-all"
+          >
+            Godta alle informasjonskapsler
+          </Button>
+        </Stack>
+      </div>
+    </Box>
+  );
 }
 
 export default CookieBannerA;

--- a/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerB.tsx
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/CookieBannerB.tsx
@@ -1,167 +1,174 @@
-import  React, { useEffect, useMemo } from "react";
-
-import {ConsentData, getCreatedAtValue, setCookie} from "./cookieBannerUtils";
-import {BodyLong, BodyShort, Box, Button, Heading, Link, Stack} from "@navikt/ds-react";
+import React, { useEffect, useMemo } from "react";
+import { updateConsent } from "./cookieBannerUtils";
+import { BodyLong, Box, Button, Heading, Link, Stack } from "@navikt/ds-react";
 
 export type CookieBannerVariant = "A" | "B";
 export type CookieBannerAcceptedPayload = Readonly<{
-    variant: CookieBannerVariant;
-    url: string;
+  variant: CookieBannerVariant;
+  url: string;
 }>;
 
 type HeadingLevel = "1" | "2" | "3" | "4" | "5" | "6";
 
 export type CookieBannerProps = {
-    headingLevel?: HeadingLevel;
+  headingLevel?: HeadingLevel;
 
-    /** Kalles hvis lagring av cookie feiler */
-    onError?: (error: unknown) => void;
+  /** Kalles hvis lagring av cookie feiler */
+  onError?: (error: unknown) => void;
 
-    /** Eksterne hooks – disse kalles ETTER at komponenten ev. har satt cookie */
-    onNecessaryOnly?: () => void;
-    onAcceptAll?: () => void;
+  /** Eksterne hooks – disse kalles ETTER at komponenten ev. har satt cookie */
+  onNecessaryOnly?: () => void;
+  onAcceptAll?: () => void;
 
-    /** Lifecycle */
-    onOpen?: () => void;
-    onClose?: () => void;
+  /** Lifecycle */
+  onOpen?: () => void;
+  onClose?: () => void;
 
-    /**
-     * Bevar disse localStorage-nøklene når banneret vises (clear + reinsert).
-     * Default: ["isDebug"].
-     */
-    preserveLocalStorageKeys?: readonly string[];
+  /**
+   * Bevar disse localStorage-nøklene når banneret vises (clear + reinsert).
+   * Default: ["isDebug"].
+   */
+  preserveLocalStorageKeys?: readonly string[];
 
-    /**
-     * Default: false.
-     * Hvis true, så vil komponenten IKKE sette consent-cookie automatisk.
-     * Du kan da selv håndtere lagring i onAcceptAll/onNecessaryOnly.
-     */
-    disableAutoCookie?: boolean;
+  /**
+   * Default: false.
+   * Hvis true, så vil komponenten IKKE sette consent-cookie automatisk.
+   * Du kan da selv håndtere lagring i onAcceptAll/onNecessaryOnly.
+   */
+  disableAutoCookie?: boolean;
 
-    /** Just in case du vil endre lenke/tekst uten å wrappe komponenten */
-    cookieInfoHref?: string;
-    titleId?: string;
-    sectionId?: string;
-    variant?: CookieBannerVariant;
-    getUrl?: () => string;
-    onAcceptedAllTrack?: (payload: CookieBannerAcceptedPayload) => void;
+  /** Just in case du vil endre lenke/tekst uten å wrappe komponenten */
+  cookieInfoHref?: string;
+  titleId?: string;
+  sectionId?: string;
+  variant?: CookieBannerVariant;
+  getUrl?: () => string;
+  onAcceptedAllTrack?: (payload: CookieBannerAcceptedPayload) => void;
 };
 
-const CONSENT_VERSION = 1 as const;
+const defaultGetUrl = (): string => {
+  if (typeof window === "undefined") return "/";
+  return window.location.pathname;
+};
 
-const buildConsentData = (acceptedAll: boolean): ConsentData => {
-    const createdAt = getCreatedAtValue();
-    const nowIso = new Date().toISOString();
+export default function CookieBannerB({
+  headingLevel = "1",
+  onError,
+  onNecessaryOnly,
+  onAcceptAll,
+  onOpen,
+  onClose,
+  preserveLocalStorageKeys = ["isDebug"],
+  disableAutoCookie = false,
+  cookieInfoHref = "/informasjonskapsler",
+  titleId = "arb-cookie-banner-title",
+  sectionId = "arb-cookie-banner-section",
+  variant = "A",
+  getUrl = defaultGetUrl,
+  onAcceptedAllTrack,
+}: CookieBannerProps) {
+  // memoize lista slik at effect ikke rerunner pga referanseendring
+  const preservedKeys = useMemo<readonly string[]>(
+    () => preserveLocalStorageKeys,
+    [preserveLocalStorageKeys]
+  );
 
-    return {
+  useEffect(() => {
+    try {
+      const preserved: Record<string, string> = {};
+      preservedKeys.forEach((key) => {
+        const val = localStorage.getItem(key);
+        if (val !== null) preserved[key] = val;
+      });
+
+      localStorage.clear();
+
+      Object.entries(preserved).forEach(([k, v]) => {
+        localStorage.setItem(k, v);
+      });
+    } catch {
+      // Bevisst stilletiende – localStorage kan være disabled
+    }
+  }, [preservedKeys]);
+
+  useEffect(() => {
+    onOpen?.();
+  }, [onOpen]);
+
+  const persistConsentSafely = (acceptedAll: boolean): void => {
+    if (disableAutoCookie) return;
+    try {
+      updateConsent({
         consent: { analytics: acceptedAll },
         userActionTaken: true,
-        meta: { createdAt, updatedAt: nowIso, version: CONSENT_VERSION },
-    };
-};
-const defaultGetUrl = (): string => {
-    if (typeof window === "undefined") return "/";
-    return window.location.pathname;
-};
-export default function CookieBannerB({
-    headingLevel = "1",
-    onError,
-    onNecessaryOnly,
-    onAcceptAll,
-    onOpen,
-    onClose,
-    preserveLocalStorageKeys = ["isDebug"],
-    disableAutoCookie = false,
-    cookieInfoHref = "/informasjonskapsler",
-    titleId = "arb-cookie-banner-title",
-    sectionId = "arb-cookie-banner-section",
-    variant = "A",
-    getUrl = defaultGetUrl,
-    onAcceptedAllTrack,
-}: CookieBannerProps) {
-    // memoize lista slik at effect ikke rerunner pga referanseendring
-    const preservedKeys = useMemo<readonly string[]>(() => preserveLocalStorageKeys, [preserveLocalStorageKeys]);
+      });
+    } catch (err) {
+      onError?.(err);
+    }
+  };
 
-    useEffect(() => {
-        try {
-            const preserved: Record<string, string> = {};
-            preservedKeys.forEach((key) => {
-                const val = localStorage.getItem(key);
-                if (val !== null) preserved[key] = val;
-            });
+  const handleNecessaryOnlyClick = (): void => {
+    persistConsentSafely(false);
+    onNecessaryOnly?.();
+    onClose?.();
+  };
 
-            localStorage.clear();
+  const handleAcceptAllClick = (): void => {
+    persistConsentSafely(true);
+    onAcceptAll?.();
+    onClose?.();
+    onAcceptedAllTrack?.({
+      variant,
+      url: getUrl(),
+    });
+  };
 
-            Object.entries(preserved).forEach(([k, v]) => {
-                localStorage.setItem(k, v);
-            });
-        } catch {
-            // Bevisst stilletiende – localStorage kan være disabled
-        }
-    }, [preservedKeys]);
-
-    useEffect(() => {
-        onOpen?.();
-    }, [onOpen]);
-
-    const persistConsentSafely = (acceptedAll: boolean): void => {
-        if (disableAutoCookie) return;
-        try {
-            const data = buildConsentData(acceptedAll);
-            setCookie(data);
-        } catch (err) {
-            onError?.(err);
-        }
-    };
-
-    const handleNecessaryOnlyClick = (): void => {
-        persistConsentSafely(false);
-        onNecessaryOnly?.();
-        onClose?.();
-    };
-
-    const handleAcceptAllClick = (): void => {
-        persistConsentSafely(true);
-        onAcceptAll?.();
-        onClose?.();
-        onAcceptedAllTrack?.({
-            variant,
-            url: getUrl(),
-        });
-    };
-
-    return (
-        <Box
-            as="section"
-            aria-labelledby={titleId}
-            id={sectionId}
-            padding={{ xs: "6", md: "8" }}
-            background="surface-alt-2-subtle"
+  return (
+    <Box
+      as="section"
+      aria-labelledby={titleId}
+      id={sectionId}
+      padding={{ xs: "6", md: "8" }}
+      background="surface-alt-2-subtle"
+    >
+      <div className="container-large">
+        <Heading
+          level={headingLevel}
+          size="large"
+          spacing
+          id="arb-cookie-banner-title"
         >
-            <div className="container-large">
-                <Heading level={headingLevel} size="large" spacing id="arb-cookie-banner-title">
-                    Cookies for en trygg og bedre tjeneste
-                </Heading>
-                <BodyLong spacing={true}>
-                    Nødvendige cookies må til for at siden skal fungere. Godtar du alle, kan vi bruke anonymisert
-                    statistikk til å forbedre jobbsøket.{" "}
-                    <strong>Uansett valg deler vi aldri dine data med andre.</strong> Du kan endre valget senere.
-                </BodyLong>
-                <BodyLong spacing={true}>
-                    <Link href={cookieInfoHref} variant="neutral" inlineText>
-                        Mer om informasjonskapsler på arbeidsplassen.no
-                    </Link>
-                </BodyLong>
+          Cookies for en trygg og bedre tjeneste
+        </Heading>
+        <BodyLong spacing={true}>
+          Nødvendige cookies må til for at siden skal fungere. Godtar du alle,
+          kan vi bruke anonymisert statistikk til å forbedre jobbsøket.{" "}
+          <strong>Uansett valg deler vi aldri dine data med andre.</strong> Du
+          kan endre valget senere.
+        </BodyLong>
+        <BodyLong spacing={true}>
+          <Link href={cookieInfoHref} variant="neutral" inlineText>
+            Mer om informasjonskapsler på arbeidsplassen.no
+          </Link>
+        </BodyLong>
 
-                <Stack gap="2" direction={{ xs: "column", sm: "row" }}>
-                    <Button type="button" variant="secondary-neutral" onClick={handleNecessaryOnlyClick}>
-                        Kun nødvendige
-                    </Button>
-                    <Button type="button" variant="secondary-neutral" onClick={handleAcceptAllClick}>
-                        Godta alle informasjonskapsler
-                    </Button>
-                </Stack>
-            </div>
-        </Box>
-    );
+        <Stack gap="2" direction={{ xs: "column", sm: "row" }}>
+          <Button
+            type="button"
+            variant="secondary-neutral"
+            onClick={handleNecessaryOnlyClick}
+          >
+            Kun nødvendige
+          </Button>
+          <Button
+            type="button"
+            variant="secondary-neutral"
+            onClick={handleAcceptAllClick}
+          >
+            Godta alle informasjonskapsler
+          </Button>
+        </Stack>
+      </div>
+    </Box>
+  );
 }

--- a/src/packages/arbeidsplassen-react/CookieBannerAB/consentCookie.ts
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/consentCookie.ts
@@ -1,0 +1,274 @@
+import { z } from "zod";
+import { writeBrowserCookie } from "./cookieWrite";
+
+/** ---------- Konstanter ---------- */
+export const CONSENT_COOKIE_NAME = "arbeidsplassen-consent";
+export const CONSENT_COOKIE_MAX_AGE_DAYS = 90 as const;
+
+/** ---------- Typer (V1 anbefalt struktur) ---------- */
+export type ConsentV1 = {
+  version: 1;
+  timestamp: {
+    createdAt: string; // ISO 8601
+    updatedAt: string; // ISO 8601
+  };
+  consent: {
+    analytics: boolean;
+  };
+  state: {
+    userActionTaken: boolean;
+  };
+};
+
+/** Legacy: nåværende cookie hos dere (for migrering) */
+export type LegacyConsent = {
+  consent: { analytics: boolean };
+  userActionTaken: boolean;
+  meta: {
+    createdAt: string;
+    updatedAt: string;
+    version: number;
+  };
+};
+
+/** ---------- Zod schema ---------- */
+const isoDatetime = z
+  .string()
+  .refine((s) => !Number.isNaN(Date.parse(s)), { message: "Invalid ISO date" });
+
+export const ConsentV1Schema = z.object({
+  version: z.literal(1),
+  timestamp: z.object({
+    createdAt: isoDatetime,
+    updatedAt: isoDatetime,
+  }),
+  consent: z.object({
+    analytics: z.boolean(),
+  }),
+  state: z.object({
+    userActionTaken: z.boolean(),
+  }),
+});
+
+export type ConsentCookie = z.infer<typeof ConsentV1Schema>;
+
+/** ---------- Helpers: tid & cookie ---------- */
+const nowIso = (): string => new Date().toISOString();
+
+const tryJsonParse = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+};
+
+const readRawCookie = (name: string): string | undefined => {
+  if (typeof document === "undefined") return undefined;
+  const match = document.cookie
+    .split(";")
+    .map((v) => v.trim())
+    .find((v) => v.startsWith(`${name}=`));
+  if (!match) return undefined;
+  const value = match.substring(name.length + 1);
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+/** ---------- Migrering fra legacy ---------- */
+const isLegacy = (u: unknown): u is LegacyConsent => {
+  if (!u || typeof u !== "object") return false;
+  const o = u as Record<string, unknown>;
+  const consent = o["consent"];
+  const uat = o["userActionTaken"];
+  const meta = o["meta"];
+  return (
+    !!consent &&
+    typeof (consent as Record<string, unknown>).analytics === "boolean" &&
+    typeof uat === "boolean" &&
+    !!meta &&
+    typeof (meta as Record<string, unknown>).createdAt === "string" &&
+    typeof (meta as Record<string, unknown>).updatedAt === "string"
+  );
+};
+
+export const migrateLegacyToV1 = (u: LegacyConsent): ConsentV1 => ({
+  version: 1,
+  timestamp: {
+    createdAt: u.meta.createdAt,
+    updatedAt: u.meta.updatedAt,
+  },
+  consent: {
+    analytics: u.consent.analytics,
+  },
+  state: {
+    userActionTaken: u.userActionTaken,
+  },
+});
+
+/** ---------- Parse + normalisering ---------- */
+export const parseConsentCookie = (
+  raw: string | undefined
+): ConsentCookie | null => {
+  if (!raw) return null;
+  const data = tryJsonParse(raw);
+  if (!data) return null;
+
+  // Først: forsøk V1
+  const v1 = ConsentV1Schema.safeParse(data);
+  if (v1.success) return v1.data;
+
+  // Deretter: forsøk legacy -> migrer -> valider
+  if (isLegacy(data)) {
+    const migrated = migrateLegacyToV1(data);
+    const validated = ConsentV1Schema.safeParse(migrated);
+    return validated.success ? validated.data : null;
+  }
+
+  return null;
+};
+
+/** ---------- Public API ---------- */
+
+/** Leser og validerer samtykke-cookien. */
+export const readConsent = (): ConsentCookie | null => {
+  const raw = readRawCookie(CONSENT_COOKIE_NAME);
+  if (!raw) return null;
+
+  const parsed = tryJsonParse(raw);
+
+  // V1 direkte?
+  const v1 = ConsentV1Schema.safeParse(parsed);
+  if (v1.success) return v1.data;
+
+  // Legacy? Migrer → skriv V1 tilbake → returner V1
+  if (isLegacy(parsed)) {
+    const migrated = migrateLegacyToV1(parsed);
+    writeConsent(migrated);
+    return migrated;
+  }
+
+  return null;
+};
+
+/** Skriver en komplett ConsentV1 til cookie (overstyrer hele objektet). */
+export const writeConsent = (
+  consent: ConsentCookie,
+  days: number = CONSENT_COOKIE_MAX_AGE_DAYS
+): void => {
+  const payload = JSON.stringify(consent);
+  writeBrowserCookie({
+    name: CONSENT_COOKIE_NAME,
+    value: payload,
+    days,
+    path: "/",
+    sameSite: "Lax",
+  });
+};
+
+/** Oppretter ny cookie hvis mangler, ellers oppdaterer felt + updatedAt. */
+export const upsertConsent = (
+  updater: (prev: ConsentCookie | null) => ConsentCookie
+): ConsentCookie => {
+  const prev = readConsent();
+  const next = updater(prev);
+  // sørg for å oppdatere updatedAt (men bevar createdAt)
+  const createdAt = prev?.timestamp.createdAt ?? nowIso();
+  const nextNormalized: ConsentCookie = {
+    ...next,
+    version: 1,
+    timestamp: {
+      createdAt,
+      updatedAt: nowIso(),
+    },
+  };
+  writeConsent(nextNormalized);
+  return nextNormalized;
+};
+
+/** Convenience: toggle/set analytics. */
+export const setAnalyticsConsent = (enabled: boolean): ConsentCookie => {
+  return upsertConsent((prev) => ({
+    version: 1,
+    timestamp: {
+      createdAt: prev?.timestamp.createdAt ?? nowIso(),
+      updatedAt: nowIso(),
+    },
+    consent: {
+      analytics: enabled,
+    },
+    state: {
+      userActionTaken: true,
+    },
+  }));
+};
+
+/** Hent nåværende analytics-samtykke (false hvis mangler/ugyldig). */
+export const getAnalyticsConsent = (): boolean => {
+  const c = readConsent();
+  return c?.consent.analytics ?? false;
+};
+
+// --- Ekstra helpers for server/edge ---
+
+/** Parse Consent-cookie fra en Cookie-header (server/edge). */
+export const readConsentFromCookieHeader = (
+  cookieHeader: string | null | undefined
+): ConsentCookie | null => {
+  if (!cookieHeader) return null;
+  const parts = cookieHeader.split(";").map((c) => c.trim());
+  const hit = parts.find((p) => p.startsWith(`${CONSENT_COOKIE_NAME}=`));
+  if (!hit) return null;
+
+  const raw = decodeURIComponent(hit.slice(CONSENT_COOKIE_NAME.length + 1));
+  // Prøv V1
+  const v1 = parseConsentCookie(raw);
+  if (v1) return v1;
+  // Prøv legacy → migrer
+  const maybeLegacy = tryJsonParse(raw);
+  if (isLegacy(maybeLegacy)) {
+    const migrated = migrateLegacyToV1(maybeLegacy);
+    return migrated; // skriv tilbake i respons med makeSetCookieHeader hvis ønsket
+  }
+  return null;
+};
+
+export const makeSetCookieHeader = (
+  consent: ConsentCookie,
+  maxAgeDays = CONSENT_COOKIE_MAX_AGE_DAYS,
+  opts?: {
+    domain?: string;
+    sameSite?: "Lax" | "Strict" | "None";
+    secure?: boolean;
+    isHttps?: boolean;
+  }
+): string => {
+  const sameSite = opts?.sameSite ?? "Lax";
+  const isHttps = opts?.isHttps ?? true; // prod default
+  const mustSecure = sameSite === "None";
+  const secureFlag =
+    typeof opts?.secure === "boolean"
+      ? opts.secure
+      : mustSecure
+      ? true
+      : isHttps;
+
+  const value = encodeURIComponent(JSON.stringify(consent));
+  const maxAge = Math.round(maxAgeDays * 86400);
+  const expires = new Date(Date.now() + maxAge * 1000).toUTCString();
+
+  const parts = [
+    `${CONSENT_COOKIE_NAME}=${value}`,
+    `Expires=${expires}`,
+    `Max-Age=${maxAge}`,
+    `Path=/`,
+    `SameSite=${sameSite}`,
+  ];
+  if (opts?.domain) parts.push(`Domain=${opts.domain}`);
+  if (secureFlag) parts.push("Secure");
+
+  return parts.join("; ");
+};

--- a/src/packages/arbeidsplassen-react/CookieBannerAB/cookieWrite.ts
+++ b/src/packages/arbeidsplassen-react/CookieBannerAB/cookieWrite.ts
@@ -1,0 +1,49 @@
+// cookieWrite.ts
+type SameSiteValue = "Lax" | "Strict" | "None";
+
+type WriteCookieOptions = {
+    name: string;
+    value: string;
+    days?: number;           // default 90
+    path?: string;           // default "/"
+    domain?: string;         // default undefined (host-scoped)
+    sameSite?: SameSiteValue;// default "Lax"
+    secure?: boolean;        // default: infer from protocol OR required by SameSite=None
+};
+
+const defaultDays = 90 as const;
+
+export const writeBrowserCookie = (opts: WriteCookieOptions): void => {
+    if (typeof document === "undefined") return;
+
+    const {
+        name,
+        value,
+        days = defaultDays,
+        path = "/",
+        domain,
+        sameSite = "Lax",
+        secure,
+    } = opts;
+
+    // Best effort: https? => secure true; http (localhost) => secure false.
+    const isHttps = typeof window !== "undefined" && window.location.protocol === "https:";
+    const mustSecure = sameSite === "None";
+    const secureFlag = typeof secure === "boolean" ? secure : (mustSecure ? true : isHttps);
+
+    // Calculate expiry
+    const maxAgeSeconds = Math.round(days * 86400);
+    const expiresUTC = new Date(Date.now() + maxAgeSeconds * 1000).toUTCString();
+
+    // Build attributes
+    const parts: string[] = [];
+    parts.push(`${name}=${encodeURIComponent(value)}`);
+    parts.push(`Expires=${expiresUTC}`);
+    parts.push(`Max-Age=${maxAgeSeconds}`);
+    parts.push(`Path=${path}`);
+    if (domain) parts.push(`Domain=${domain}`);
+    parts.push(`SameSite=${sameSite}`);
+    if (secureFlag) parts.push("Secure");
+
+    document.cookie = parts.join("; ");
+};

--- a/src/packages/arbeidsplassen-react/package.json
+++ b/src/packages/arbeidsplassen-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@navikt/arbeidsplassen-react",
-  "version": "8.8.2",
+  "version": "9.8.2",
   "main": "dist/index.js",
   "module": "dist/index.js",
   "private": false,
@@ -35,6 +35,7 @@
   ],
   "homepage": "https://github.com/navikt/arbeidsplassen-design#readme",
   "description": "",
+  "peerDependencies": { "zod": "^4.1.11" },
   "devDependencies": {
     "@navikt/ds-react": "^7.30.1",
     "@babel/cli": "^7.28.3",
@@ -45,7 +46,8 @@
     "typescript": "^5.5.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@types/node": "^20.0.0"
+    "@types/node": "^20.0.0",
+     "zod": "^4.1.11"
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1"


### PR DESCRIPTION
- legg til Zod-validering og oppdater skrivelogikk
- innfører V1-consent schema (timestamp/consent/state) med Zod-validering
- auto-migrerer legacy-cookie til V1 ved lesing (klient + server-helper)
- skriver cookies med SameSite=Lax, betinget Secure, samt Expires + Max-Age
- legger til server-helpers: readConsentFromCookieHeader
- refaktorerer CookieBanner til å bruke updateConsent() i stedet for manuell payload
- beholder bakoverkompatibilitet via cookiebannerUtils-adapter

This pull request refactors the cookie consent logic in the `arbeidsplassen-react` package, introducing a new, versioned consent cookie structure with validation via Zod. The changes improve cookie handling, migration from legacy formats, and documentation for consumers of the package. The most important changes are grouped below.

**Cookie Consent Refactor and Validation:**

* Added a new file `consentCookie.ts` implementing a versioned consent cookie structure (`ConsentV1`), validation with Zod, migration from legacy consent formats, and helpers for reading/writing cookies both in browser and server contexts.
* Refactored `cookieBannerUtils.ts` to use the new consent cookie helpers and types from `consentCookie.ts`, improving type safety and maintainability.

**Cookie Banner Components Update:**

* Updated `CookieBannerA.tsx` and `CookieBannerB.tsx` to use the new `updateConsent` method, removing legacy consent creation logic and simplifying consent persistence. [[1]](diffhunk://#diff-66550d0cc98903450bab4661582f64d9e82f41faa2c42ec6e4b12bac18ffe1fdL2-R11) [[2]](diffhunk://#diff-66550d0cc98903450bab4661582f64d9e82f41faa2c42ec6e4b12bac18ffe1fdL50-L61) [[3]](diffhunk://#diff-66550d0cc98903450bab4661582f64d9e82f41faa2c42ec6e4b12bac18ffe1fdL110-R111) [[4]](diffhunk://#diff-66550d0cc98903450bab4661582f64d9e82f41faa2c42ec6e4b12bac18ffe1fdL83-R81) [[5]](diffhunk://#diff-66550d0cc98903450bab4661582f64d9e82f41faa2c42ec6e4b12bac18ffe1fdL147-R148) [[6]](diffhunk://#diff-66550d0cc98903450bab4661582f64d9e82f41faa2c42ec6e4b12bac18ffe1fdL175) [[7]](diffhunk://#diff-857ddcef02b3565ae96b6e40214b081b63b6f49f541a3ec596b6e82c99590246L2-R3) [[8]](diffhunk://#diff-857ddcef02b3565ae96b6e40214b081b63b6f49f541a3ec596b6e82c99590246L50-R53) [[9]](diffhunk://#diff-857ddcef02b3565ae96b6e40214b081b63b6f49f541a3ec596b6e82c99590246L83-R74) [[10]](diffhunk://#diff-857ddcef02b3565ae96b6e40214b081b63b6f49f541a3ec596b6e82c99590246L110-R104) [[11]](diffhunk://#diff-857ddcef02b3565ae96b6e40214b081b63b6f49f541a3ec596b6e82c99590246L142-R147) [[12]](diffhunk://#diff-857ddcef02b3565ae96b6e40214b081b63b6f49f541a3ec596b6e82c99590246L157-R167)

**Documentation and Dependency Updates:**

* Updated `README.md` to document the new requirement for Zod as a peer dependency and clarify installation instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R41) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R76)
* Added `zod@^4.1.11` as a dependency in `package.json` to support schema validation for consent cookies.